### PR TITLE
Bug fix for Callbacks

### DIFF
--- a/nemoguardrails/logging/callbacks.py
+++ b/nemoguardrails/logging/callbacks.py
@@ -241,4 +241,6 @@ logging_callback_manager_for_chain = AsyncCallbackManagerForChainRun(
     parent_run_id=None,
     handlers=handlers,
     inheritable_handlers=handlers,
+    tags=[],
+    inheritable_tags=[],
 )


### PR DESCRIPTION
Was getting a

"BaseRunManager.__init__() missing 2 required keyword-only arugments: 'tags' and 'inheritable_tags'"

error.

AsyncCallbackManagerForChainRun inherits AsyncRunManager which inherits BaseRunManager which requires tags and inheritable_tags arguments. We can set these to empty lists.